### PR TITLE
[GOORM-35]-회원가입 및 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -40,6 +41,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/goorm/kgu/familynote/common/auth/application/UserDetailService.java
+++ b/src/main/java/goorm/kgu/familynote/common/auth/application/UserDetailService.java
@@ -1,0 +1,18 @@
+package goorm.kgu.familynote.common.auth.application;
+
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import goorm.kgu.familynote.domain.user.application.UserService;
+import goorm.kgu.familynote.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+@Service
+@RequiredArgsConstructor
+public class UserDetailService implements UserDetailsService {
+	private final UserService userService;
+
+	@Override
+	public User loadUserByUsername(String nickname) {
+		return userService.getUserByNickname(nickname);
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/common/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/goorm/kgu/familynote/common/auth/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package goorm.kgu.familynote.common.auth.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import goorm.kgu.familynote.common.auth.jwt.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+	private final TokenProvider tokenProvider;
+	private final static String HEADER_AUTHORIZATION = "Authorization";
+	private final static String TOKEN_PREFIX = "Bearer ";
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
+		ServletException, IOException {
+		String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+		String token = getAccessToken(authorizationHeader);
+		if (tokenProvider.validateToken(token)) {
+			Authentication authentication = tokenProvider.getAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private String getAccessToken(String authorizationHeader) {
+		if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+			return authorizationHeader.substring(TOKEN_PREFIX.length());
+		}
+		return null;
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/common/auth/jwt/JwtProperties.java
+++ b/src/main/java/goorm/kgu/familynote/common/auth/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package goorm.kgu.familynote.common.auth.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+	private String issuer;
+	private String secretKey;
+}

--- a/src/main/java/goorm/kgu/familynote/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/goorm/kgu/familynote/common/auth/jwt/TokenProvider.java
@@ -1,0 +1,79 @@
+package goorm.kgu.familynote.common.auth.jwt;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import goorm.kgu.familynote.domain.user.domain.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+	private final JwtProperties jwtProperties;
+
+	public String generateToken(User user, Duration expiredAt) {
+		Date now = new Date();
+		return makeToken(new Date(now.getTime() + expiredAt.toMillis()), user);
+	}
+
+	private String makeToken(Date expiry, User user) {
+		Date now = new Date();
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setIssuer(jwtProperties.getIssuer())
+			.setIssuedAt(now)
+			.setExpiration(expiry)
+			.setSubject(user.getNickname())
+			.claim("id", user.getNickname())
+			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+			.compact();
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parser()
+				.setSigningKey(jwtProperties.getSecretKey())
+				.parseClaimsJws(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	public Authentication getAuthentication(String token) {
+		Claims claims = getClaims(token);
+		Set<SimpleGrantedAuthority> authorities = Collections.singleton(
+			new SimpleGrantedAuthority("ROLE_USER")
+		);
+		return new UsernamePasswordAuthenticationToken(
+			new org.springframework.security.core.userdetails.User(
+				claims.getSubject(),
+				"",
+				authorities
+			), token, authorities
+		);
+	}
+
+	public String getUserId(String token) {
+		Claims claims = getClaims(token);
+		return claims.get("id", String.class);
+	}
+
+	private Claims getClaims(String token) {
+		return Jwts.parser()
+			.setSigningKey(jwtProperties.getSecretKey())
+			.parseClaimsJws(token)
+			.getBody();
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/application/LoginService.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/application/LoginService.java
@@ -1,0 +1,40 @@
+package goorm.kgu.familynote.domain.login.application;
+
+import java.time.Duration;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import goorm.kgu.familynote.common.auth.jwt.TokenProvider;
+import goorm.kgu.familynote.domain.login.presentation.exception.InvalidPasswordException;
+import goorm.kgu.familynote.domain.login.presentation.request.LoginRequest;
+import goorm.kgu.familynote.domain.login.presentation.response.LoginSucceedResponse;
+import goorm.kgu.familynote.domain.user.application.UserService;
+import goorm.kgu.familynote.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+	private final UserService userService;
+	private final PasswordEncoder passwordEncoder;
+	private final TokenProvider tokenProvider;
+
+	@Transactional
+	public LoginSucceedResponse login(LoginRequest request) {
+		String nickname = request.nickname();
+		String password = request.password();
+
+		User user = userService.getUserByNickname(nickname);
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new InvalidPasswordException();
+		}
+
+		String refreshToken = tokenProvider.generateToken(user, Duration.ofDays(7));
+		String accessToken = tokenProvider.generateToken(user, Duration.ofHours(2));
+		userService.updateRefreshToken(nickname, refreshToken);
+
+		return LoginSucceedResponse.of(accessToken, refreshToken);
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/LoginController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/LoginController.java
@@ -1,0 +1,54 @@
+package goorm.kgu.familynote.domain.login.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import goorm.kgu.familynote.common.exception.ExceptionResponse;
+import goorm.kgu.familynote.domain.login.application.LoginService;
+import goorm.kgu.familynote.domain.login.presentation.request.LoginRequest;
+import goorm.kgu.familynote.domain.login.presentation.response.LoginSucceedResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "로그인", description = "로그인 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class LoginController {
+	private final LoginService loginService;
+
+	@Operation(summary = "로그인", description = "로그인을 수행합니다.")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "로그인 성공",
+			content = @Content(schema = @Schema(implementation = LoginSucceedResponse.class))
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = "비밀번호가 일치하지 않습니다.",
+			content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "회원을 찾을 수 없습니다.",
+			content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+		)
+	})
+	@PostMapping("/login")
+	public ResponseEntity<LoginSucceedResponse> login(
+		@Valid @RequestBody LoginRequest request
+	) {
+		LoginSucceedResponse response = loginService.login(request);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/InvalidPasswordException.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/InvalidPasswordException.java
@@ -1,0 +1,11 @@
+package goorm.kgu.familynote.domain.login.presentation.exception;
+
+import static goorm.kgu.familynote.domain.login.presentation.exception.LoginExceptionCode.INVALID_PASSWORD;
+
+import goorm.kgu.familynote.common.exception.CustomException;
+
+public class InvalidPasswordException extends CustomException {
+	public InvalidPasswordException() {
+		super(INVALID_PASSWORD);
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/LoginExceptionCode.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/LoginExceptionCode.java
@@ -1,0 +1,26 @@
+package goorm.kgu.familynote.domain.login.presentation.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import org.springframework.http.HttpStatus;
+
+import goorm.kgu.familynote.common.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LoginExceptionCode implements ExceptionCode {
+
+	INVALID_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return this.name();
+	}
+}
+

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/request/LoginRequest.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/request/LoginRequest.java
@@ -1,0 +1,18 @@
+package goorm.kgu.familynote.domain.login.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record LoginRequest(
+	@Schema(description = "닉네임", example = "umm_programer", requiredMode = REQUIRED)
+	@NotNull
+	String nickname,
+
+	@Schema(description = "비밀번호", example = "password1234", requiredMode = REQUIRED)
+	@NotNull
+	String password
+) {
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/request/LoginRequest.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/request/LoginRequest.java
@@ -4,7 +4,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 public record LoginRequest(
 	@Schema(description = "닉네임", example = "umm_programer", requiredMode = REQUIRED)

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/response/LoginSucceedResponse.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/response/LoginSucceedResponse.java
@@ -1,0 +1,17 @@
+package goorm.kgu.familynote.domain.login.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginSucceedResponse (
+	@Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTYzNzQwNjQwMH0.7J", requiredMode = REQUIRED)
+	String accessToken,
+
+	@Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsILJdhDYTYzNzQwNjQwMH0.7J", requiredMode = REQUIRED)
+	String refreshToken
+) {
+	public static LoginSucceedResponse of(String accessToken, String refreshToken) {
+		return new LoginSucceedResponse(accessToken, refreshToken);
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/user/application/UserService.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/application/UserService.java
@@ -1,12 +1,39 @@
 package goorm.kgu.familynote.domain.user.application;
 
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import goorm.kgu.familynote.domain.user.domain.User;
 import goorm.kgu.familynote.domain.user.domain.UserRepository;
+import goorm.kgu.familynote.domain.user.presentation.exception.NotFoundUserException;
+import goorm.kgu.familynote.domain.user.presentation.request.UserCreateRequest;
+import goorm.kgu.familynote.domain.user.presentation.response.UserPersistResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
+	private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+	@Transactional
+	public UserPersistResponse createUser(UserCreateRequest request) {
+		User user = User.create(
+			request.nickname(),
+			bCryptPasswordEncoder.encode(request.password())
+		);
+		Long id = userRepository.save(user).getId();
+		return UserPersistResponse.of(id);
+	}
+
+	public void updateRefreshToken(String nickname, String refreshToken) {
+		User user = getUserByNickname(nickname);
+		user.updateRefreshToken(refreshToken);
+	}
+
+	public User getUserByNickname(String nickname) {
+		return userRepository.findByNickname(nickname)
+			.orElseThrow(NotFoundUserException::new);
+	}
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/domain/User.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/domain/User.java
@@ -1,8 +1,18 @@
 package goorm.kgu.familynote.domain.user.domain;
 
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
 import goorm.kgu.familynote.common.domain.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -17,14 +27,43 @@ import lombok.NoArgsConstructor;
 @Table(name = "\"user\"")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseTimeEntity {
+public class User extends BaseTimeEntity  implements UserDetails {
 
 	@Id
-	@Column(nullable = false)
-	private String id;
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
 
 	@Column(nullable = false)
-	private String name;
+	private String nickname;
 
-	private String email;
+	@Column(nullable = false)
+	private String password;
+
+	private String refreshToken;
+
+	public static User create(String nickname, String password) {
+		return User.builder()
+			.nickname(nickname)
+			.password(password)
+			.build();
+	}
+
+	public void updateRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+	@Override
+	public String getPassword() {
+		return password;
+	}
+
+	@Override
+	public String getUsername() {
+		return nickname;
+	}
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/domain/UserRepository.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/domain/UserRepository.java
@@ -1,4 +1,9 @@
 package goorm.kgu.familynote.domain.user.domain;
 
+import java.util.Optional;
+
 public interface UserRepository {
+	User save(User user);
+
+	Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/JpaUserRepository.java
@@ -1,8 +1,11 @@
 package goorm.kgu.familynote.domain.user.infrastructure;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import goorm.kgu.familynote.domain.user.domain.User;
 
 public interface JpaUserRepository extends JpaRepository<User, Long>{
+	Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/UserRepositoryImpl.java
@@ -1,7 +1,10 @@
 package goorm.kgu.familynote.domain.user.infrastructure;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
+import goorm.kgu.familynote.domain.user.domain.User;
 import goorm.kgu.familynote.domain.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -9,4 +12,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepository {
 	private final JpaUserRepository jpaUserRepository;
+
+	@Override
+	public User save(User user) {
+		return jpaUserRepository.save(user);
+	}
+
+	@Override
+	public Optional<User> findByNickname(String nickname) {
+		return jpaUserRepository.findByNickname(nickname);
+	}
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/UserController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/UserController.java
@@ -1,10 +1,24 @@
 package goorm.kgu.familynote.domain.user.presentation;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import goorm.kgu.familynote.domain.user.application.UserService;
+import goorm.kgu.familynote.domain.user.presentation.request.UserCreateRequest;
+import goorm.kgu.familynote.domain.user.presentation.response.UserPersistResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -13,4 +27,23 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "User", description = "유저 관련 api / 담당자 : 이한음")
 public class UserController {
 	private final UserService userService;
+
+	@Operation(summary = "회원 생성", description = "회원을 생성합니다.")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "201",
+			description = "회원 생성 성공",
+			content = @Content(schema = @Schema(implementation = UserPersistResponse.class))
+		)
+	})
+	@ResponseStatus(CREATED)
+	@PostMapping
+	public ResponseEntity<UserPersistResponse> createUser(
+		@Valid @RequestBody UserCreateRequest request
+	) {
+		UserPersistResponse response = userService.createUser(request);
+		return ResponseEntity.ok(response);
+	}
+
+
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/request/UserCreateRequest.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/request/UserCreateRequest.java
@@ -1,0 +1,20 @@
+package goorm.kgu.familynote.domain.user.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record UserCreateRequest(
+	@Schema(description = "닉네임", example = "umm_programer", requiredMode = REQUIRED)
+	@NotNull
+	String nickname,
+
+	@Schema(description = "비밀번호", example = "password1234", requiredMode = REQUIRED)
+	@NotNull @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z]).{8,}$", message = "비밀번호는 최소 8자리 이상, 영문자와 숫자를 포함해야 합니다.")
+	String password
+
+	// TODO : 닉네임 길이 제한 및 비밀번호 패턴에 대한 논의 필요
+) {
+}

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/request/UserRequest.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/request/UserRequest.java
@@ -1,8 +1,0 @@
-package goorm.kgu.familynote.domain.user.presentation.request;
-
-public record UserRequest(
-	String name,
-	String email,
-	String password
-) {
-}

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/response/UserPersistResponse.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/response/UserPersistResponse.java
@@ -1,0 +1,14 @@
+package goorm.kgu.familynote.domain.user.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserPersistResponse(
+	@Schema(description = "유저 ID", example = "1", requiredMode = REQUIRED)
+	Long id
+) {
+	public static UserPersistResponse of(Long id) {
+		return new UserPersistResponse(id);
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/response/UserResponse.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/response/UserResponse.java
@@ -1,8 +1,0 @@
-package goorm.kgu.familynote.domain.user.presentation.response;
-
-public record UserResponse(
-	Long id,
-	String name,
-	String email
-) {
-}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,4 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,7 @@ springdoc:
   swagger-ui:
     operations-sorter: alpha
     tags-sorter: alpha
+
+jwt:
+  issuer: ${JWT_ISSUER}
+  secret_key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
### 📍 [GOORM-35]-회원가입 및 로그인 API

## *⛳️ Work Description*
- 닉네임, 패스워드 기반 회원가입 API를 구현하였습니다.
- 로그인 API를 구현하였고 로그인 시 액세스 토큰은 SecurityContextHolder에, 리프레시 토큰은 DB에 저장합니다.
- 기타 security 및 validation 설정을 추가하였습니다. 


## *📸 Screenshot*
<img width="1728" alt="스크린샷 2024-09-06 오후 1 31 12" src="https://github.com/user-attachments/assets/c3726031-b6df-458e-b11a-dfa2573d29e5">


*📢 To Reviewers*
-  family 및 family member API 개발 이후 Redis를 붙일 예정입니다.