### PR TITLE
[GOORM-39] 기본 질문 생성 API 작성

### DIFF
--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/application/BaseQuestionService.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/application/BaseQuestionService.java
@@ -4,6 +4,7 @@ import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestion;
 import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestionRepository;
 import goorm.kgu.familynote.domain.question.baseQuestion.presentation.request.BaseQuestionCreateRequest;
 import goorm.kgu.familynote.domain.question.baseQuestion.presentation.response.BaseQuestionResponse;
+import goorm.kgu.familynote.domain.question.baseQuestion.presentation.response.BaseQuestionResponseList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +17,11 @@ public class BaseQuestionService {
     private final BaseQuestionRepository baseQuestionRepository;
 
     @Transactional
-    public List<BaseQuestionResponse> saveBaseQuestions(List<BaseQuestionCreateRequest> requests) {
-        return requests.stream()
+    public BaseQuestionResponseList saveBaseQuestions(List<BaseQuestionCreateRequest> requests) {
+        List<BaseQuestionResponse> baseQuestionResponseList = requests.stream()
                 .map(this::saveBaseQuestion)
                 .collect(Collectors.toList());
+        return BaseQuestionResponseList.of(baseQuestionResponseList);
     }
 
     private BaseQuestionResponse saveBaseQuestion(BaseQuestionCreateRequest request) {

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/application/BaseQuestionService.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/application/BaseQuestionService.java
@@ -1,0 +1,31 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.application;
+
+import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestion;
+import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestionRepository;
+import goorm.kgu.familynote.domain.question.baseQuestion.presentation.request.BaseQuestionCreateRequest;
+import goorm.kgu.familynote.domain.question.baseQuestion.presentation.response.BaseQuestionResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BaseQuestionService {
+    private final BaseQuestionRepository baseQuestionRepository;
+
+    @Transactional
+    public List<BaseQuestionResponse> saveBaseQuestions(List<BaseQuestionCreateRequest> requests) {
+        return requests.stream()
+                .map(this::saveBaseQuestion)
+                .collect(Collectors.toList());
+    }
+
+    private BaseQuestionResponse saveBaseQuestion(BaseQuestionCreateRequest request) {
+        BaseQuestion baseQuestion = BaseQuestion.create(request.content());
+        baseQuestionRepository.save(baseQuestion);
+        return BaseQuestionResponse.of(baseQuestion);
+    }
+
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/domain/BaseQuestion.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/domain/BaseQuestion.java
@@ -4,6 +4,7 @@ import goorm.kgu.familynote.common.domain.BaseTimeEntity;
 import goorm.kgu.familynote.domain.family.family.domain.Family;
 import goorm.kgu.familynote.domain.family.member.domain.FamilyMember;
 import goorm.kgu.familynote.domain.user.domain.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -28,6 +29,7 @@ public class BaseQuestion extends BaseTimeEntity {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String content;
 
     public static BaseQuestion create(String content) {

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/domain/BaseQuestion.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/domain/BaseQuestion.java
@@ -1,0 +1,39 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.domain;
+
+import goorm.kgu.familynote.common.domain.BaseTimeEntity;
+import goorm.kgu.familynote.domain.family.family.domain.Family;
+import goorm.kgu.familynote.domain.family.member.domain.FamilyMember;
+import goorm.kgu.familynote.domain.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "base_question")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseQuestion extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String content;
+
+    public static BaseQuestion create(String content) {
+        return BaseQuestion.builder()
+                .content(content)
+                .build();
+    }
+
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/domain/BaseQuestionRepository.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/domain/BaseQuestionRepository.java
@@ -1,0 +1,8 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.domain;
+
+
+public interface BaseQuestionRepository {
+
+    BaseQuestion save(BaseQuestion baseQuestion);
+
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/infrastructure/BaseQuestionRepositoryImpl.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/infrastructure/BaseQuestionRepositoryImpl.java
@@ -1,0 +1,17 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.infrastructure;
+
+import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestion;
+import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BaseQuestionRepositoryImpl implements BaseQuestionRepository {
+    private final JpaBaseQuestionRepository jpaBaseQuestionRepository;
+
+    @Override
+    public BaseQuestion save(BaseQuestion baseQuestion) {
+        return jpaBaseQuestionRepository.save(baseQuestion);
+    }
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/infrastructure/JpaBaseQuestionRepository.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/infrastructure/JpaBaseQuestionRepository.java
@@ -1,0 +1,7 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.infrastructure;
+
+import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaBaseQuestionRepository extends JpaRepository<BaseQuestion, Long> {
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/BaseQuestionController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/BaseQuestionController.java
@@ -26,7 +26,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/baseQuestion")
+@RequestMapping("/api/v1/question/base")
 @Tag(name = "Base Question", description = "기본 질문 관련 api / 담당자 : 전민주")
 public class BaseQuestionController {
     private final BaseQuestionService baseQuestionService;

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/BaseQuestionController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/BaseQuestionController.java
@@ -1,0 +1,51 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.presentation;
+
+import goorm.kgu.familynote.common.exception.ExceptionResponse;
+import goorm.kgu.familynote.domain.family.family.presentation.response.FamilyPersistResponse;
+import goorm.kgu.familynote.domain.family.member.presentation.request.FamilyMemberCreateRequest;
+import goorm.kgu.familynote.domain.question.baseQuestion.application.BaseQuestionService;
+import goorm.kgu.familynote.domain.question.baseQuestion.presentation.request.BaseQuestionCreateRequest;
+import goorm.kgu.familynote.domain.question.baseQuestion.presentation.response.BaseQuestionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/baseQuestion")
+@Tag(name = "Base Question", description = "기본 질문 관련 api / 담당자 : 전민주")
+public class BaseQuestionController {
+    private final BaseQuestionService baseQuestionService;
+
+    @Operation(summary = "기본 질문 등록", description = "기본 질문을 등록합니다. 개발자/관리자가 API를 통해서 조작할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "기본 질문 등록 성공",
+                    content = @Content(schema = @Schema(implementation = FamilyPersistResponse.class))
+            )
+    })
+    @ResponseStatus(CREATED)
+    @PostMapping
+    public ResponseEntity<List<BaseQuestionResponse>> createBaseQuestions(
+            @Valid @RequestBody List<BaseQuestionCreateRequest> requests
+    ) {
+        List<BaseQuestionResponse> response = baseQuestionService.saveBaseQuestions(requests);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/BaseQuestionController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/BaseQuestionController.java
@@ -6,6 +6,7 @@ import goorm.kgu.familynote.domain.family.member.presentation.request.FamilyMemb
 import goorm.kgu.familynote.domain.question.baseQuestion.application.BaseQuestionService;
 import goorm.kgu.familynote.domain.question.baseQuestion.presentation.request.BaseQuestionCreateRequest;
 import goorm.kgu.familynote.domain.question.baseQuestion.presentation.response.BaseQuestionResponse;
+import goorm.kgu.familynote.domain.question.baseQuestion.presentation.response.BaseQuestionResponseList;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -41,10 +42,10 @@ public class BaseQuestionController {
     })
     @ResponseStatus(CREATED)
     @PostMapping
-    public ResponseEntity<List<BaseQuestionResponse>> createBaseQuestions(
+    public ResponseEntity<BaseQuestionResponseList> createBaseQuestions(
             @Valid @RequestBody List<BaseQuestionCreateRequest> requests
     ) {
-        List<BaseQuestionResponse> response = baseQuestionService.saveBaseQuestions(requests);
+        BaseQuestionResponseList response = baseQuestionService.saveBaseQuestions(requests);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/request/BaseQuestionCreateRequest.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/request/BaseQuestionCreateRequest.java
@@ -1,0 +1,11 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record BaseQuestionCreateRequest(
+        @Schema(description = "기본 질문 내용", example = "탕수육 먹을 때 부먹 vs 찍먹", requiredMode = REQUIRED)
+        String content
+) {
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/response/BaseQuestionResponse.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/response/BaseQuestionResponse.java
@@ -1,0 +1,30 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.presentation.response;
+
+import goorm.kgu.familynote.domain.question.baseQuestion.domain.BaseQuestion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record BaseQuestionResponse(
+    @Schema(description = "기본 질문 id", example = "1", requiredMode = REQUIRED)
+    Long baseQuestionId,
+
+    @Schema(description = "기본 질문 내용", example = "짜장면 vs 짬뽕", requiredMode = REQUIRED)
+    String content
+) {
+
+    public static List<BaseQuestionResponse> of(List<BaseQuestion> baseQuestions) {
+        return baseQuestions.stream()
+                .map(BaseQuestionResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public static BaseQuestionResponse of(BaseQuestion baseQuestion) {
+        return new BaseQuestionResponse(
+                baseQuestion.getId(),
+                baseQuestion.getContent()
+        );
+    }
+}

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/response/BaseQuestionResponseList.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/response/BaseQuestionResponseList.java
@@ -6,11 +6,15 @@ import java.util.List;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record BaseQuestionResponseList (
-        @Schema(description = "기본 질문 리스트", example =
-                "    [{\"content\": \"오늘 하루 중 가장 즐거웠던 일은 무엇이었나요?\"},\n" +
-                "    {\"content\": \"요즘 가장 관심 있는 취미나 활동은 무엇인가요?\"},\n" +
-                "    {\"content\": \"어렸을 때의 꿈은 무엇이었나요? 지금도 그 꿈이 있나요?\"}]", requiredMode = REQUIRED)
-        List<BaseQuestionResponse> baseQuestionResponseList
+    @Schema(
+        description = "기본 질문 리스트",
+        example =
+        "    [{\"content\": \"오늘 하루 중 가장 즐거웠던 일은 무엇이었나요?\"},\n" +
+        "    {\"content\": \"요즘 가장 관심 있는 취미나 활동은 무엇인가요?\"},\n" +
+        "    {\"content\": \"어렸을 때의 꿈은 무엇이었나요? 지금도 그 꿈이 있나요?\"}]",
+        requiredMode = REQUIRED
+    )
+    List<BaseQuestionResponse> contents
 ) {
 
     public static BaseQuestionResponseList of(List<BaseQuestionResponse> baseQuestionResponseList) {

--- a/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/response/BaseQuestionResponseList.java
+++ b/src/main/java/goorm/kgu/familynote/domain/question/baseQuestion/presentation/response/BaseQuestionResponseList.java
@@ -1,0 +1,21 @@
+package goorm.kgu.familynote.domain.question.baseQuestion.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record BaseQuestionResponseList (
+        @Schema(description = "기본 질문 리스트", example =
+                "    [{\"content\": \"오늘 하루 중 가장 즐거웠던 일은 무엇이었나요?\"},\n" +
+                "    {\"content\": \"요즘 가장 관심 있는 취미나 활동은 무엇인가요?\"},\n" +
+                "    {\"content\": \"어렸을 때의 꿈은 무엇이었나요? 지금도 그 꿈이 있나요?\"}]", requiredMode = REQUIRED)
+        List<BaseQuestionResponse> baseQuestionResponseList
+) {
+
+    public static BaseQuestionResponseList of(List<BaseQuestionResponse> baseQuestionResponseList) {
+        return new BaseQuestionResponseList(
+                baseQuestionResponseList
+        );
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,4 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 5252
+
 spring:
   application:
     name: family-note-server
@@ -8,7 +11,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
       default_batch_fetch_size: 1000
       jdbc:
         time_zone: Asia/Seoul

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
       default_batch_fetch_size: 1000
       jdbc:
         time_zone: Asia/Seoul


### PR DESCRIPTION
### 📍 [GOORM-39] 기본 질문 생성 API 작성

## *⛳️ Work Description*
- BaseQuestion 관련 코드 세팅
- 기본 질문 리스트를 입력받고 DB에 저장할 수 있는 API 작성 (더미 데이터 삽입용) 

## *📸 Screenshot*
**DB에 기본 질문 더미데이터가 적재된 모습입니다.**
<img width="637" alt="image" src="https://github.com/user-attachments/assets/84f968fa-22ae-4bcb-b222-3c418f37c3ac">
**스웨거 실행 시 요청/응답 모습입니다.**
![image](https://github.com/user-attachments/assets/5d14905f-94ca-4cf3-b04e-85d5d0be191a)

*📢 To Reviewers*
- 더미데이터 적재용 API 만들면서 BaseQuestion 도메인 기본 세팅 진행하였습니다.
- yml에 변경된 부분이 있습니다. 확인해주세요.