### PR TITLE
[GOORM-66]-유저 생성 시 닉네임 중복 검사 로직 추가

### DIFF
--- a/src/main/java/goorm/kgu/familynote/domain/user/application/UserService.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/application/UserService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import goorm.kgu.familynote.domain.user.domain.User;
 import goorm.kgu.familynote.domain.user.domain.UserRepository;
+import goorm.kgu.familynote.domain.user.presentation.exception.UserNicknameDuplicatedException;
 import goorm.kgu.familynote.domain.user.presentation.exception.UserNotAuthenticatedException;
 import goorm.kgu.familynote.domain.user.presentation.exception.UserNotFoundException;
 import goorm.kgu.familynote.domain.user.presentation.request.UserCreateRequest;
@@ -25,6 +26,7 @@ public class UserService {
 
 	@Transactional
 	public UserPersistResponse createUser(UserCreateRequest request) {
+		validateNicknameDuplication(request.nickname());
 		User user = User.create(
 			request.nickname(),
 			bCryptPasswordEncoder.encode(request.password())
@@ -66,5 +68,11 @@ public class UserService {
 	public User getUserById(Long id) {
 		return userRepository.findById(id)
 			.orElseThrow(UserNotFoundException::new);
+	}
+
+	private void validateNicknameDuplication(String nickname) {
+		if (userRepository.existsByNickname(nickname)) {
+			throw new UserNicknameDuplicatedException();
+		}
 	}
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/domain/UserRepository.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/domain/UserRepository.java
@@ -10,5 +10,7 @@ public interface UserRepository {
 
 	Optional<User> findByNickname(String nickname);
 
+	boolean existsByNickname(String nickname);
+
 	List<User> findByNicknameContaining(String nickname);
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/JpaUserRepository.java
@@ -10,5 +10,7 @@ import goorm.kgu.familynote.domain.user.domain.User;
 public interface JpaUserRepository extends JpaRepository<User, Long>{
 	Optional<User> findByNickname(String nickname);
 
+	boolean existsByNickname(String nickname);
+
 	List<User> findByNicknameContaining(String nickname);
 }

--- a/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/infrastructure/UserRepositoryImpl.java
@@ -30,6 +30,11 @@ public class UserRepositoryImpl implements UserRepository {
 	}
 
 	@Override
+	public boolean existsByNickname(String nickname) {
+		return jpaUserRepository.existsByNickname(nickname);
+	}
+
+	@Override
 	public List<User> findByNicknameContaining(String nickname) {
 		return jpaUserRepository.findByNicknameContaining(nickname);
 	}

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/UserController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import goorm.kgu.familynote.common.exception.ExceptionResponse;
 import goorm.kgu.familynote.domain.user.application.UserService;
 import goorm.kgu.familynote.domain.user.presentation.request.UserCreateRequest;
 import goorm.kgu.familynote.domain.user.presentation.response.UserListResponse;
@@ -38,6 +39,11 @@ public class UserController {
 			responseCode = "201",
 			description = "유저 생성 성공",
 			content = @Content(schema = @Schema(implementation = UserPersistResponse.class))
+		),
+		@ApiResponse(
+			responseCode = "409",
+			description = "중복된 닉네임 입니다.",
+			content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
 		)
 	})
 	@ResponseStatus(CREATED)

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/exception/UserExceptionCode.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/exception/UserExceptionCode.java
@@ -1,5 +1,6 @@
 package goorm.kgu.familynote.domain.user.presentation.exception;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -14,6 +15,7 @@ import lombok.Getter;
 public enum UserExceptionCode implements ExceptionCode {
 	USER_NOT_AUTHENTICATED(FORBIDDEN, "사용자 인증에 실패하였습니다."),
 	USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
+	USER_NICKNAME_DUPLICATED(CONFLICT, "중복된 닉네임 입니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/goorm/kgu/familynote/domain/user/presentation/exception/UserNicknameDuplicatedException.java
+++ b/src/main/java/goorm/kgu/familynote/domain/user/presentation/exception/UserNicknameDuplicatedException.java
@@ -1,0 +1,11 @@
+package goorm.kgu.familynote.domain.user.presentation.exception;
+
+import static goorm.kgu.familynote.domain.user.presentation.exception.UserExceptionCode.USER_NICKNAME_DUPLICATED;
+
+import goorm.kgu.familynote.common.exception.CustomException;
+
+public class UserNicknameDuplicatedException extends CustomException {
+	public UserNicknameDuplicatedException() {
+		super(USER_NICKNAME_DUPLICATED);
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,4 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update


### PR DESCRIPTION
### 📍 [GOORM-66]-유저 생성 시 닉네임 중복 검사 로직 추가

## *⛳️ Work Description*
- 유저 생성 시 닉네임 중복 검사 로직을 추가하였습니다.
- application-local.yml의 ddl-auto를 update로 변경하였습니다.

## *📸 Screenshot*
<img width="1413" alt="스크린샷 2024-09-19 오전 11 01 34" src="https://github.com/user-attachments/assets/6d560f35-3b37-4d7c-861d-1ebcd145c008">

*📢 To Reviewers*
- 인텔리제이 프로파일 설정을 local로 잡아놓았기 때문에 RDS가 연동되어 있는 상태에서 create는 다소 위험하기에 update로 변경했습니다.