### PR TITLE
[GOORM-75]- familynote 도메인 CORS 이슈 픽스

### DIFF
--- a/src/main/java/goorm/kgu/familynote/common/config/SecurityConfig.java
+++ b/src/main/java/goorm/kgu/familynote/common/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
 			CorsConfiguration config = new CorsConfiguration();
 			config.setAllowedHeaders(Collections.singletonList("*"));
 			config.setAllowedMethods(Collections.singletonList("*"));
-			config.setAllowedOriginPatterns(Arrays.asList("http://localhost:5173", "http://211.188.49.236:5173"));
+			config.setAllowedOriginPatterns(Arrays.asList("http://localhost:5173", "http://211.188.49.236:5173", "https://familynote.ezbooks.kr/"));
 			config.setAllowCredentials(true);
 			return config;
 		};


### PR DESCRIPTION
### 📍 [GOORM-75]- familynote 도메인 CORS 이슈 픽스

## *⛳️ Work Description*
- familynote.ezbooks.kr에서 발생하는 CORS 에러를 해결하였습니다.

## *📸 Screenshot*

*📢 To Reviewers*
- 빠른 Approve 부탁합니다