### PR TITLE
[GOORM-41]-redis 연동 AT 재발급 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/goorm/kgu/familynote/common/config/RedisConfig.java
+++ b/src/main/java/goorm/kgu/familynote/common/config/RedisConfig.java
@@ -1,0 +1,4 @@
+package goorm.kgu.familynote.common.config;
+
+public class RedisConfig {
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/domain/RefreshToken.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/domain/RefreshToken.java
@@ -1,0 +1,29 @@
+package goorm.kgu.familynote.domain.login.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 7)
+public class RefreshToken {
+
+	@Id
+	private String refreshToken;
+	private Long userId;
+
+	public RefreshToken(String refreshToken, Long userId) {
+		this.refreshToken = refreshToken;
+		this.userId = userId;
+	}
+
+	public static RefreshToken of(String refreshToken, Long userId) {
+		return RefreshToken.builder()
+			.refreshToken(refreshToken)
+			.userId(userId)
+			.build();
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/domain/RefreshToken.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/domain/RefreshToken.java
@@ -26,4 +26,5 @@ public class RefreshToken {
 			.userId(userId)
 			.build();
 	}
+
 }

--- a/src/main/java/goorm/kgu/familynote/domain/login/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/infrastructure/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package goorm.kgu.familynote.domain.login.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import goorm.kgu.familynote.domain.login.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long>{
+	Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/LoginController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/LoginController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import goorm.kgu.familynote.common.exception.ExceptionResponse;
 import goorm.kgu.familynote.domain.login.application.LoginService;
 import goorm.kgu.familynote.domain.login.presentation.request.LoginRequest;
+import goorm.kgu.familynote.domain.login.presentation.request.RefreshTokenRequest;
+import goorm.kgu.familynote.domain.login.presentation.response.AccessTokenResponse;
 import goorm.kgu.familynote.domain.login.presentation.response.LoginSucceedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -49,6 +51,15 @@ public class LoginController {
 		@Valid @RequestBody LoginRequest request
 	) {
 		LoginSucceedResponse response = loginService.login(request);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용해 새로운 액세스 토큰을 발급합니다.")
+	@PostMapping("/reissue")
+	public ResponseEntity<AccessTokenResponse> reissue(
+		@Valid @RequestBody RefreshTokenRequest request
+	) {
+		AccessTokenResponse response = loginService.reissue(request);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/LoginController.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/LoginController.java
@@ -55,6 +55,18 @@ public class LoginController {
 	}
 
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용해 새로운 액세스 토큰을 발급합니다.")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "토큰 재발급 성공",
+			content = @Content(schema = @Schema(implementation = AccessTokenResponse.class))
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "유효한 토큰을 찾을 수 없습니다.",
+			content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+		)
+	})
 	@PostMapping("/reissue")
 	public ResponseEntity<AccessTokenResponse> reissue(
 		@Valid @RequestBody RefreshTokenRequest request

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/LoginExceptionCode.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/LoginExceptionCode.java
@@ -1,6 +1,7 @@
 package goorm.kgu.familynote.domain.login.presentation.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import org.springframework.http.HttpStatus;
 
@@ -13,6 +14,7 @@ import lombok.Getter;
 public enum LoginExceptionCode implements ExceptionCode {
 
 	INVALID_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+	TOKEN_NOT_FOUND(NOT_FOUND, "유효한 토큰을 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/TokenNotFoundException.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/exception/TokenNotFoundException.java
@@ -1,0 +1,11 @@
+package goorm.kgu.familynote.domain.login.presentation.exception;
+
+import static goorm.kgu.familynote.domain.login.presentation.exception.LoginExceptionCode.TOKEN_NOT_FOUND;
+
+import goorm.kgu.familynote.common.exception.CustomException;
+
+public class TokenNotFoundException extends CustomException {
+	public TokenNotFoundException() {
+		super(TOKEN_NOT_FOUND);
+	}
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/request/RefreshTokenRequest.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/request/RefreshTokenRequest.java
@@ -1,0 +1,13 @@
+package goorm.kgu.familynote.domain.login.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record RefreshTokenRequest(
+	@Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsILJdhDYTYzNzQwNjQwMH0.7J", requiredMode = REQUIRED)
+	@NotNull
+	String refreshToken
+) {
+}

--- a/src/main/java/goorm/kgu/familynote/domain/login/presentation/response/AccessTokenResponse.java
+++ b/src/main/java/goorm/kgu/familynote/domain/login/presentation/response/AccessTokenResponse.java
@@ -1,0 +1,18 @@
+package goorm.kgu.familynote.domain.login.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AccessTokenResponse(
+	@Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyfQ", requiredMode = REQUIRED)
+	String accessToken
+) {
+	public static AccessTokenResponse of(String accessToken) {
+		return AccessTokenResponse.builder()
+			.accessToken(accessToken)
+			.build();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,11 @@ spring:
     defer-datasource-initialization: true
     show-sql: true
     open-in-view: false
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
 
 springdoc:
   default-consumes-media-type: application/json


### PR DESCRIPTION
### 📍 [GOORM-41]-redis 연동 AT 재발급 API

## *⛳️ Work Description*
- redis 관련 설정을 추가하였습니다.
- RT와 userId를 Redis에 저장한 후 RT를 기반으로 AT를 재발급 합니다.

## *📸 Screenshot*
<img width="1480" alt="스크린샷 2024-09-24 오후 8 13 36" src="https://github.com/user-attachments/assets/a8469e91-6f02-43a6-911d-fc2f871f90c0">


*📢 To Reviewers*
- 